### PR TITLE
Change the way overlay get destroyed.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -38,7 +38,7 @@ class DomInspector {
 	destroy() {
 		this.destroyed = true;
 		this.disable();
-		this.overlay.remove();
+		this.overlay = {};
 	}
 	getXPath(ele) {
 		if (!isDOM(ele) && !this.target) return logger.warn('Target element is not found. Warning function name:%c getXPath', 'color: #ff5151');


### PR DESCRIPTION
Needs testing but in my case original statement this.overlay.remove() causing error in console: No .remove() method exists....